### PR TITLE
:wrench: Config: fix eslint parserOptions project directory -20211121

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     ecmaVersion: 13,
     sourceType: 'module',
-    project: './tsconfig.json',
+    project: './client/tsconfig.json',
   },
   plugins: ['react', 'react-hooks', '@typescript-eslint', 'prettier'],
   rules: {


### PR DESCRIPTION
1. eslint 설정 파일의 프로젝트 경로가 잘못되어 올바르게 수정 ( client 내 모든 파일에 에러가 발생하는 원인 )